### PR TITLE
재생목록 프로세스 변경 됨

### DIFF
--- a/src/plugins/router.js
+++ b/src/plugins/router.js
@@ -18,7 +18,7 @@ const router = new VueRouter({
     },
     {
       path: "/playList/:id",
-      name: "playList",
+      name: "Playlist",
       component: require("@/components/Videos/index").default,
       meta: { transition: 'overlay-down-full' }
     },

--- a/src/store/modules/player.module.js
+++ b/src/store/modules/player.module.js
@@ -7,6 +7,7 @@
 
 const state = {
   playingVideoInfo: {
+    isUse: false,
     coverData: {
       channelId: "",
       playlistId: "",
@@ -40,6 +41,7 @@ const mutations = {
     state.playingVideoInfo.thumbnails = payload.thumbnails;
     state.playingVideoInfo.playIndex = payload.listIndex
     state.playingVideoInfo.duration = payload.duration;
+    state.playingVideoInfo.isUse = true
   }
 };
 const actions = {


### PR DESCRIPTION
### [재생목록 프로세스 변경]

**＊임시 재생목록 항목이 추가 됨.**

**재생중인 음악이 있다는건, 원본 재생목록이 이미 존재하며, 재생 대기 목록도 존재함을 의미함.**

1. 재생중인 음악이 없고, 재생목록을 조회할 경우
- 재생목록에서 비디오를 클릭하여, 음악을 재생하게 되면, 현재 재생목록은 원본 목록에 추가 됨.
   - 현재 재생중인 비디오 목록이 없다면, 재생 대기 목록도 함께 추가 됨.
- 이후 같은 재생목록을 조회시, 비지니스 로직을 거치지 않고, 원본 재생목록의 데이터를 사용함.
- 같은 재생목록에서 페이징 조회시, 재생 대기 목록과 동기화 됨.
   - 페이징 조회는, 재생전/재생후 동일하게 재생 대기 목록에 함께 동기화 됨.
- 재생 대기 목록에서 비디오를 삭제해도 원본 재생목록에는 동기화 되지 않음.
   - 원본 재생 목록은 원본의 목록을 유지함.

2. 재생중인 음악이 있고, 다른 재생목록을 조회할 경우
- 음악이 재생중이라면, 다른 재생목록 조회시에는 임시 재생목록에 추가 됨.
   - 또 다른 재생목록 조회시에는 이전 임시 재생목록을 덮어 씀.
- 임시 재생목록에서 페이징 조회시 임시 재생목록과 병합 됨.
- 임시 재생목록에서 비디오를 클릭하여 음악을 재생할 경우, 현재 임시 재생목록의 모든 데이터를,
  원본 데이터로 이전하고, 재생 대기 목록역시 새로 이전한다. 데이터 이전이 완료 되면, 임시 데이터
  목록은 모두 초기화 한다.
 